### PR TITLE
feat: improve api request count for node drain action

### DIFF
--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -20,10 +20,6 @@ import (
 	"github.com/castai/cluster-controller/castai"
 )
 
-var (
-	errPodPresent = errors.New("pod is still present")
-)
-
 type drainNodeConfig struct {
 	podsDeleteTimeout   time.Duration
 	podDeleteRetries    uint64
@@ -73,19 +69,10 @@ func (h *drainNodeHandler) Handle(ctx context.Context, data interface{}) error {
 		return fmt.Errorf("tainting node %q: %w", req.NodeName, err)
 	}
 
-	allNodePods, err := h.listNodePods(ctx, node)
-	if err != nil {
-		return fmt.Errorf("listing pods for node %q: %w", req.NodeName, err)
-	}
-
-	podsToEvict := lo.Filter(allNodePods.Items, func(pod v1.Pod, _ int) bool {
-		return !isDaemonSetPod(&pod) && !isStaticPod(&pod)
-	})
-
 	// First try to evict pods gracefully.
 	evictCtx, evictCancel := context.WithTimeout(ctx, time.Duration(req.DrainTimeoutSeconds)*time.Second)
 	defer evictCancel()
-	err = h.evictPods(evictCtx, log, podsToEvict)
+	err = h.evictNodePods(evictCtx, log, node)
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
@@ -97,7 +84,7 @@ func (h *drainNodeHandler) Handle(ctx context.Context, data interface{}) error {
 		// If force is set and evict timeout exceeded delete pods.
 		deleteCtx, deleteCancel := context.WithTimeout(ctx, h.cfg.podsDeleteTimeout)
 		defer deleteCancel()
-		if err := h.deletePods(deleteCtx, log, podsToEvict); err != nil {
+		if err := h.deleteNodePods(deleteCtx, log, node); err != nil {
 			return err
 		}
 	}
@@ -107,55 +94,6 @@ func (h *drainNodeHandler) Handle(ctx context.Context, data interface{}) error {
 	return nil
 }
 
-func (h *drainNodeHandler) deletePods(ctx context.Context, log logrus.FieldLogger, pods []v1.Pod) error {
-	log.Infof("forcefully deleting %d pods", len(pods))
-
-	g, ctx := errgroup.WithContext(ctx)
-	for _, pod := range pods {
-		pod := pod
-
-		g.Go(func() error {
-			err := h.deletePod(ctx, pod)
-			if err != nil {
-				return err
-			}
-			return h.waitPodTerminated(ctx, log, pod)
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("deleting pods: %w", err)
-	}
-
-	return nil
-}
-
-func (h *drainNodeHandler) deletePod(ctx context.Context, pod v1.Pod) error {
-	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(h.cfg.podDeleteRetryDelay), h.cfg.podDeleteRetries), ctx) // nolint:gomnd
-	action := func() error {
-		err := h.clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-		if err != nil {
-			// Pod is not found - ignore.
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-
-			// Pod is misconfigured - stop retry.
-			if apierrors.IsInternalError(err) {
-				return backoff.Permanent(err)
-			}
-		}
-
-		// Other errors - retry.
-		return err
-	}
-	if err := backoff.Retry(action, b); err != nil {
-		return fmt.Errorf("deleting pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
-	}
-	return nil
-}
-
-// taintNode to make it unshedulable.
 func (h *drainNodeHandler) taintNode(ctx context.Context, node *v1.Node) error {
 	if node.Spec.Unschedulable {
 		return nil
@@ -171,10 +109,56 @@ func (h *drainNodeHandler) taintNode(ctx context.Context, node *v1.Node) error {
 	return nil
 }
 
-// listNodePods returns a list of all pods scheduled on the provided node.
-func (h *drainNodeHandler) listNodePods(ctx context.Context, node *v1.Node) (*v1.PodList, error) {
+func (h *drainNodeHandler) evictNodePods(ctx context.Context, log logrus.FieldLogger, node *v1.Node) error {
+	pods, err := h.listNodePodsToEvict(ctx, node)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("evicting %d pods", len(pods))
+
+	if err := h.sendPodsRequests(ctx, pods, h.evictPod); err != nil {
+		return fmt.Errorf("sending evict pods requests: %w", err)
+	}
+
+	return h.waitNodePodsTerminated(ctx, node)
+}
+
+func (h *drainNodeHandler) deleteNodePods(ctx context.Context, log logrus.FieldLogger, node *v1.Node) error {
+	pods, err := h.listNodePodsToEvict(ctx, node)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("forcefully deleting %d pods", len(pods))
+
+	if err := h.sendPodsRequests(ctx, pods, h.deletePod); err != nil {
+		return fmt.Errorf("sending delete pods requests: %w", err)
+	}
+
+	return h.waitNodePodsTerminated(ctx, node)
+}
+
+func (h *drainNodeHandler) sendPodsRequests(ctx context.Context, pods []v1.Pod, f func(context.Context, v1.Pod) error) error {
+	const batchSize = 5
+
+	for _, batch := range lo.Chunk(pods, batchSize) {
+		g, ctx := errgroup.WithContext(ctx)
+		for _, pod := range batch {
+			pod := pod
+			g.Go(func() error { return f(ctx, pod) })
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *drainNodeHandler) listNodePodsToEvict(ctx context.Context, node *v1.Node) ([]v1.Pod, error) {
 	var pods *v1.PodList
-	err := backoff.Retry(func() error {
+	if err := backoff.Retry(func() error {
 		p, err := h.clientset.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
 		})
@@ -183,58 +167,28 @@ func (h *drainNodeHandler) listNodePods(ctx context.Context, node *v1.Node) (*v1
 		}
 		pods = p
 		return nil
-	}, defaultBackoff(ctx))
-	return pods, err
-}
-
-func (h *drainNodeHandler) evictPods(ctx context.Context, log logrus.FieldLogger, pods []v1.Pod) error {
-	log.Infof("evicting %d pods", len(pods))
-
-	g, ctx := errgroup.WithContext(ctx)
-	for _, pod := range pods {
-		pod := pod
-
-		g.Go(func() error {
-			err := h.evictPod(ctx, pod)
-			if err != nil {
-				return err
-			}
-			return h.waitPodTerminated(ctx, log, pod)
-		})
+	}, defaultBackoff(ctx)); err != nil {
+		return nil, fmt.Errorf("listing node %v pods: %w", node.Name, err)
 	}
 
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("evicting pods: %w", err)
-	}
+	podsToEvict := lo.Filter(pods.Items, func(pod v1.Pod, _ int) bool {
+		return !isDaemonSetPod(&pod) && !isStaticPod(&pod)
+	})
 
-	return nil
+	return podsToEvict, nil
 }
 
-func (h *drainNodeHandler) waitPodTerminated(ctx context.Context, log logrus.FieldLogger, pod v1.Pod) error {
-	b := backoff.WithContext(backoff.NewConstantBackOff(5*time.Second), ctx) // nolint:gomnd
-
-	err := backoff.Retry(func() error {
-		p, err := h.clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-		if err != nil && apierrors.IsNotFound(err) {
-			return nil
-		}
+func (h *drainNodeHandler) waitNodePodsTerminated(ctx context.Context, node *v1.Node) error {
+	return backoff.Retry(func() error {
+		pods, err := h.listNodePodsToEvict(ctx, node)
 		if err != nil {
-			return err
+			return fmt.Errorf("waiting for node %q pods to be terminated: %w", node.Name, err)
 		}
-		// replicaSets will recreate pods with equal name and namespace, therefore we compare UIDs
-		if p.GetUID() == pod.GetUID() {
-			return errPodPresent
+		if len(pods) > 0 {
+			return fmt.Errorf("waiting for %d pods to be terminated on node %v", len(pods), node.Name)
 		}
 		return nil
-	}, b)
-	if err != nil && errors.Is(err, errPodPresent) {
-		log.Infof("timeout waiting for pod %s in namespace %s to terminate", pod.Name, pod.Namespace)
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("waiting for pod %s in namespace %s termination: %w", pod.Name, pod.Namespace, err)
-	}
-	return nil
+	}, backoff.WithContext(backoff.NewConstantBackOff(10*time.Second), ctx))
 }
 
 // evictPod from the k8s node. Error handling is based on eviction api documentation:
@@ -270,6 +224,31 @@ func (h *drainNodeHandler) evictPod(ctx context.Context, pod v1.Pod) error {
 	}
 	if err := backoff.Retry(action, b); err != nil {
 		return fmt.Errorf("evicting pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
+	}
+	return nil
+}
+
+func (h *drainNodeHandler) deletePod(ctx context.Context, pod v1.Pod) error {
+	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(h.cfg.podDeleteRetryDelay), h.cfg.podDeleteRetries), ctx) // nolint:gomnd
+	action := func() error {
+		err := h.clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			// Pod is not found - ignore.
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			// Pod is misconfigured - stop retry.
+			if apierrors.IsInternalError(err) {
+				return backoff.Permanent(err)
+			}
+		}
+
+		// Other errors - retry.
+		return err
+	}
+	if err := backoff.Retry(action, b); err != nil {
+		return fmt.Errorf("deleting pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
 	}
 	return nil
 }

--- a/actions/drain_node_handler_test.go
+++ b/actions/drain_node_handler_test.go
@@ -103,7 +103,7 @@ func TestDrainNodeHandler(t *testing.T) {
 		}
 
 		err := h.Handle(context.Background(), req)
-		r.EqualError(err, "evicting pods: evicting pod pod1 in namespace default: internal")
+		r.EqualError(err, "sending evict pods requests: evicting pod pod1 in namespace default: internal")
 
 		n, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 		r.NoError(err)


### PR DESCRIPTION
Improve drain node action by:
- batching pod requests in chunks of 5 to not overload control plane api
- do not call for each pod individually when waiting for them to be terminated on the node