### PR TITLE
Revert image, use alpine insted of distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static:nonroot
+FROM alpine:3.17.1
+RUN apk add --no-cache openssl
 ARG TARGETARCH amd64
 COPY bin/castai-cluster-controller-$TARGETARCH  /usr/local/bin/castai-cluster-controller
 CMD ["castai-cluster-controller"]


### PR DESCRIPTION
- Revert image, use alpine instead of distroless 
