### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/static-debian11
-ARG TARGETARCH amd64
+ARG TARGETARCH
 COPY bin/castai-cluster-controller-$TARGETARCH  /usr/local/bin/castai-cluster-controller
 CMD ["castai-cluster-controller"]


### PR DESCRIPTION
This doesn't take any effect. To set default value syntax is `ARG <name>[=<default value>]` (missing equal), but for some reasons docker allows such confusing syntax which does nothing.

Setting default value is also not possible because --platform will not work correctly for multi-stage build.