### PR TITLE
chore: FOSSA image scan not supported for distroless images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,3 +102,15 @@ jobs:
           tags: |
             us-docker.pkg.dev/castai-hub/library/cluster-controller:${{ env.RELEASE_TAG }}
             us-docker.pkg.dev/castai-hub/library/cluster-controller:latest
+
+      - name: Docker pull for fossa main
+        if: github.event_name == 'release'
+        run: docker pull us-docker.pkg.dev/castai-hub/library/cluster-controller:${{ env.RELEASE_TAG }}
+
+      - name: FOSSA scan docker image
+        if: github.event_name == 'release'
+        continue-on-error: true
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          container: us-docker.pkg.dev/castai-hub/library/cluster-controller:${{ env.RELEASE_TAG }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,14 +102,3 @@ jobs:
           tags: |
             us-docker.pkg.dev/castai-hub/library/cluster-controller:${{ env.RELEASE_TAG }}
             us-docker.pkg.dev/castai-hub/library/cluster-controller:latest
-
-      - name: Docker pull for fossa main
-        if: github.event_name == 'release'
-        run: docker pull us-docker.pkg.dev/castai-hub/library/cluster-controller:${{ env.RELEASE_TAG }}
-
-      - name: FOSSA scan docker image
-        if: github.event_name == 'release'
-        uses: fossas/fossa-action@v1
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          container: us-docker.pkg.dev/castai-hub/library/cluster-controller:${{ env.RELEASE_TAG }}


### PR DESCRIPTION
- FOSSA doesn't support scanning distroless https://github.com/fossas/fossa-cli/issues/1093

We still have FOSSA running on main branch/PR and also every 12h to scan