### PR TITLE
CORE-3242: skip node delete on id mismatch

### DIFF
--- a/actions/delete_node_handler.go
+++ b/actions/delete_node_handler.go
@@ -60,9 +60,25 @@ func (h *deleteNodeHandler) Handle(ctx context.Context, action *castai.ClusterAc
 	})
 	log.Info("deleting kubernetes node")
 
+	current, err := h.clientset.CoreV1().Nodes().Get(ctx, req.NodeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("node not found, skipping delete")
+			return nil
+		}
+		return fmt.Errorf("error getting node %w", err)
+	}
+
+	if val, ok := current.Labels[castai.LabelProvisionerCastAINodeID]; ok {
+		if val != "" && val != req.NodeID {
+			log.Infof("node id mismatch, expected %q got %q. Skipping delete.", req.NodeID, val)
+			return nil
+		}
+	}
+
 	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(h.cfg.deleteRetryWait), h.cfg.deleteRetries), ctx)
-	err := backoff.Retry(func() error {
-		err := h.clientset.CoreV1().Nodes().Delete(ctx, req.NodeName, metav1.DeleteOptions{})
+	err = backoff.Retry(func() error {
+		err := h.clientset.CoreV1().Nodes().Delete(ctx, current.Name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			log.Info("node not found, skipping delete")
 			return nil

--- a/actions/delete_node_handler_test.go
+++ b/actions/delete_node_handler_test.go
@@ -82,6 +82,41 @@ func TestDeleteNodeHandler(t *testing.T) {
 		r.NoError(err)
 	})
 
+	t.Run("skip delete when node id do not match", func(t *testing.T) {
+		r := require.New(t)
+		nodeName := "node1"
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Labels: map[string]string{
+					castai.LabelProvisionerCastAINodeID: "node-id",
+				},
+			},
+		}
+		clientset := fake.NewSimpleClientset(node)
+
+		action := &castai.ClusterAction{
+			ID: uuid.New().String(),
+			ActionDeleteNode: &castai.ActionDeleteNode{
+				NodeName: "node1",
+				NodeID:   "another-node-id",
+			},
+		}
+
+		h := deleteNodeHandler{
+			log:       log,
+			clientset: clientset,
+			cfg:       deleteNodeConfig{},
+		}
+
+		err := h.Handle(context.Background(), action)
+		r.NoError(err)
+
+		existing, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		r.NoError(err)
+		existing.Labels[castai.LabelProvisionerCastAINodeID] = "node-id"
+	})
+
 	t.Run("delete node with pods", func(t *testing.T) {
 		r := require.New(t)
 		nodeName := "node1"

--- a/actions/delete_node_handler_test.go
+++ b/actions/delete_node_handler_test.go
@@ -89,7 +89,7 @@ func TestDeleteNodeHandler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Labels: map[string]string{
-					castai.LabelProvisionerCastAINodeID: "node-id",
+					castai.LabelNodeID: "node-id",
 				},
 			},
 		}
@@ -114,7 +114,7 @@ func TestDeleteNodeHandler(t *testing.T) {
 
 		existing, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 		r.NoError(err)
-		existing.Labels[castai.LabelProvisionerCastAINodeID] = "node-id"
+		existing.Labels[castai.LabelNodeID] = "node-id"
 	})
 
 	t.Run("delete node with pods", func(t *testing.T) {

--- a/castai/types.go
+++ b/castai/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	LabelProvisionerCastAINodeID = "provisioner.cast.ai/node-id:"
+	LabelProvisionerCastAINodeID = "provisioner.cast.ai/node-id"
 )
 
 type GetClusterActionsResponse struct {

--- a/castai/types.go
+++ b/castai/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	LabelProvisionerCastAINodeID = "provisioner.cast.ai/node-id"
+	LabelNodeID = "provisioner.cast.ai/node-id"
 )
 
 type GetClusterActionsResponse struct {

--- a/castai/types.go
+++ b/castai/types.go
@@ -8,6 +8,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+const (
+	LabelProvisionerCastAINodeID = "provisioner.cast.ai/node-id:"
+)
+
 type GetClusterActionsResponse struct {
 	Items []*ClusterAction `json:"items"`
 }


### PR DESCRIPTION
Skip node delete when node_id mismatch for case where cloud reuses the names