### PR TITLE
CORE-3320: Add klog to logrus adapter 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/castai/cluster-controller
 go 1.19
 
 require (
+	github.com/bombsimon/logrusr/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/go-resty/resty/v2 v2.5.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bombsimon/logrusr/v4 v4.0.0 h1:Pm0InGphX0wMhPqC02t31onlq9OVyJ98eP/Vh63t1Oo=
+github.com/bombsimon/logrusr/v4 v4.0.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/bombsimon/logrusr/v4"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/castai/cluster-controller/actions"
@@ -126,7 +128,12 @@ func run(
 		"running_on":    nodeName,
 		"ctrl_pod_name": podName,
 	})
-	log.Infof("running castai-cluster-controller version %v", binVersion)
+
+	// Set logr/klog to logrus adapter so all logging goes through logrus
+	logr := logrusr.New(log)
+	klog.SetLogger(logr)
+
+	log.Infof("running castai-cluster-controller version %v, log-level: %v", binVersion, logger.Level)
 
 	actionsConfig := actions.Config{
 		PollWaitInterval: 5 * time.Second,


### PR DESCRIPTION
Unifies logging by adding logging adapter for glog (which is base for klog) so we send logs to mothership. 
Currently when go-client logs errors we are not sending those and its hard to build full picture of what is happening. 