### PR TITLE
KUBE-194: permissions might not be upgraded yet so silence forbidden error

### DIFF
--- a/actions/kubernetes_helpers.go
+++ b/actions/kubernetes_helpers.go
@@ -50,7 +50,7 @@ func patchNodeStatus(ctx context.Context, log logrus.FieldLogger, clientset kube
 		_, err := clientset.CoreV1().Nodes().PatchStatus(ctx, name, patch)
 		if k8serrors.IsForbidden(err) {
 			// permissions might be of older version that can't patch node/status
-			log.WithField("node", name).WithError(err).Error("skip patch node/status")
+			log.WithField("node", name).WithError(err).Warn("skip patch node/status")
 			return nil
 		}
 		return err

--- a/actions/patch_node_handler.go
+++ b/actions/patch_node_handler.go
@@ -100,7 +100,7 @@ func (h *patchNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		if err != nil {
 			return fmt.Errorf("marshal patch for status: %w", err)
 		}
-		return patchNodeStatus(ctx, h.clientset, node.Name, patch)
+		return patchNodeStatus(ctx, h.log, h.clientset, node.Name, patch)
 	}
 	return nil
 }


### PR DESCRIPTION
Defensive programming. If `casai-cluster-controller` was upgraded but permission to Patch `node/status` were not added we don't won't to fail the whole action.