### PR TITLE
sent log fields values must be strings otherwise 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,25 @@ Check our official helm charts repo https://github.com/castai/castai-helm-charts
 
 ## Testing
 
-### Remote
+### Pull requests
+
+Each pull request builds and publishes docker image for easier code review and testing. Check relevant GitHub actions.
+
+### On existing cluster enrolled to CAST AI
 
 Deploy cluster-controller to already connected remote cluster.
 
 *NOTE*: Make sure your kubectl context is pointing to your remote cluster.
 
-One time setup.
+Have a configured `gcloud`. Make sure to docker login with
 ```shell
-DOCKER_SECRET_TMPL_PATH=./secret-pull-script.sh ./hack/remote/setup.sh
+gcloud auth configure-docker gcr.io
+```
+
+Clone https://github.com/castai/castai-helm-charts adjacent to repo root folder. It will be used by our scripts
+```shell
+cd <cluster-controller-parent-directory>
+git clone https://github.com/castai/castai-helm-charts gh-helm-charts
 ```
 
 Deploy.

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"time"
 
@@ -142,7 +143,7 @@ func (s *service) doWork(ctx context.Context) error {
 		return nil
 	}
 
-	s.log.WithFields(logrus.Fields{"n": len(actions)}).Infof("received in %s", pollDuration)
+	s.log.WithFields(logrus.Fields{"n": strconv.Itoa(len(actions))}).Infof("received in %s", pollDuration)
 	s.handleActions(ctx, actions)
 	return nil
 }
@@ -182,7 +183,7 @@ func (s *service) handleActions(ctx context.Context, actions []*castai.ClusterAc
 			if err != nil {
 				s.log.WithFields(logrus.Fields{
 					"id":    action.ID,
-					"error": err,
+					"error": err.Error(),
 				}).Error("handle actions")
 			}
 		}(action)
@@ -221,7 +222,7 @@ func (s *service) handleAction(ctx context.Context, action *castai.ClusterAction
 
 	s.log.WithFields(logrus.Fields{
 		"id":   action.ID,
-		"type": actionType,
+		"type": actionType.String(),
 	}).Info("handle action")
 	handler, ok := s.actionHandlers[actionType]
 	if !ok {
@@ -238,7 +239,7 @@ func (s *service) ackAction(ctx context.Context, action *castai.ClusterAction, h
 	actionType := reflect.TypeOf(action.Data())
 	s.log.WithFields(logrus.Fields{
 		"id":   action.ID,
-		"type": actionType,
+		"type": actionType.String(),
 	}).Info("ack action")
 
 	return backoff.RetryNotify(func() error {

--- a/hack/remote/deploy.sh
+++ b/hack/remote/deploy.sh
@@ -21,12 +21,12 @@ if [ -z "$CLUSTER_ID" ]; then
 fi
 
 # Build bo binary and push docker image.
-IMAGE_TAG=v0.0.1
-GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=${IMAGE_TAG}" -o bin/castai-cluster-controller .
-DOCKER_IMAGE_REPO=europe-west3-docker.pkg.dev/ci-master-mo3d/tilt/$USER/castai-cluster-controller
+IMAGE_TAG="v${USER}0.0.1"
+GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=${IMAGE_TAG}" -o bin/castai-cluster-controller-amd64 .
+DOCKER_IMAGE_REPO=gcr.io/staging-eu-castai-vt5hy2/castai-cluster-controller
 
 if [ -z "$SKIP_BUILD" ]; then
-  docker build -t "$DOCKER_IMAGE_REPO:$IMAGE_TAG" .
+  docker build --build-arg TARGETARCH=amd64 -t "$DOCKER_IMAGE_REPO:$IMAGE_TAG" .
   docker push "$DOCKER_IMAGE_REPO:$IMAGE_TAG"
 fi
 


### PR DESCRIPTION
Server expects structured log fields to be `map[string]string` so for now explicitly converting values to string to avoid BAD_REQUEST/400 errors.