### PR TITLE
chore: bump golang version to 1.22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.21
+      - name: Setup Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.5'
+          go-version: '1.22.4'
 
       - name: Cache Go modules
         uses: actions/cache@v3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.5'
+          go-version: '1.22.4'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/castai/cluster-controller
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bombsimon/logrusr/v4 v4.0.0


### PR DESCRIPTION
Should fix `CVE-2024-24790` 