### PR TITLE
KUBE-479: Evict all pods even in case of PDB violations

### DIFF
--- a/actions/delete_node_handler_test.go
+++ b/actions/delete_node_handler_test.go
@@ -136,7 +136,7 @@ func TestDeleteNodeHandler(t *testing.T) {
 			cfg: deleteNodeConfig{
 				podsTerminationWait: 1,
 			},
-			drainNodeHandler: drainNodeHandler{clientset: clientset},
+			drainNodeHandler: drainNodeHandler{clientset: clientset, log: log},
 		}
 
 		err := h.Handle(context.Background(), action)

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -226,7 +226,9 @@ func (h *drainNodeHandler) sendPodsRequests(ctx context.Context, pods []v1.Pod, 
 		wg            sync.WaitGroup
 	)
 
-	h.log.Infof("Starting %d parallel tasks for %d pods: [%v]", parallelTasks, len(pods), pods)
+	h.log.Debugf("Starting %d parallel tasks for %d pods: [%v]", parallelTasks, len(pods), lo.Map(pods, func(t v1.Pod, i int) string {
+		return fmt.Sprintf("%s/%s", t.Namespace, t.Name)
+	}))
 
 	worker := func(taskChan <-chan *v1.Pod) {
 		for task := range taskChan {

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -293,6 +293,7 @@ func (h *drainNodeHandler) listNodePodsToEvict(ctx context.Context, log logrus.F
 
 		if p.Namespace == h.cfg.castNamespace && !isDaemonSetPod(&p) && !isStaticPod(&p) {
 			castPods = append(castPods, p)
+			continue
 		}
 
 		if !isDaemonSetPod(&p) && !isStaticPod(&p) {

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -80,10 +80,6 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		return fmt.Errorf("unexpected type %T for drain handler", action.Data())
 	}
 	drainTimeout := h.getDrainTimeout(action)
-	// CSU-1945 temporary reduction to force evicting even pods with violated PDBs
-	if req.Force {
-		drainTimeout = 5 * time.Second
-	}
 
 	log := h.log.WithFields(logrus.Fields{
 		"node_name":      req.NodeName,

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -117,6 +117,8 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		if !req.Force {
 			return err
 		}
+
+		h.log.Infof("timeout=%f exceeded during pod eviction, force=%v, starting pod deletion", drainTimeout.Seconds(), req.Force)
 		// Try deleting pods gracefully first, then delete with 0 grace period.
 		options := []metav1.DeleteOptions{
 			{},

--- a/actions/drain_node_handler_test.go
+++ b/actions/drain_node_handler_test.go
@@ -120,7 +120,9 @@ func TestDrainNodeHandler(t *testing.T) {
 		}
 
 		err := h.Handle(context.Background(), action)
-		r.EqualError(err, "eviciting node pods: sending evict pods requests: evicting pod pod1 in namespace default: internal")
+		r.ErrorContains(err, "eviciting node pods")
+		r.ErrorContains(err, "default/pod1")
+		r.ErrorContains(err, "internal")
 
 		n, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 		r.NoError(err)
@@ -215,7 +217,9 @@ func TestDrainNodeHandler(t *testing.T) {
 		})
 
 		err := h.Handle(context.Background(), action)
-		r.EqualError(err, "forcefully deleting pods: sending delete pods requests: deleting pod pod1 in namespace default: internal")
+		r.ErrorContains(err, "forcefully deleting pods")
+		r.ErrorContains(err, "default/pod1")
+		r.ErrorContains(err, "internal")
 
 		_, err = clientset.CoreV1().Pods("default").Get(context.Background(), podName, metav1.GetOptions{})
 		r.NoError(err)
@@ -260,7 +264,9 @@ func TestDrainNodeHandler(t *testing.T) {
 		})
 
 		err := h.Handle(context.Background(), action)
-		r.EqualError(err, "forcefully deleting pods: sending delete pods requests: deleting pod pod1 in namespace default: internal")
+		r.ErrorContains(err, "forcefully deleting pods")
+		r.ErrorContains(err, "default/pod1")
+		r.ErrorContains(err, "internal")
 
 		_, err = clientset.CoreV1().Pods("default").Get(context.Background(), podName, metav1.GetOptions{})
 		r.NoError(err)


### PR DESCRIPTION
Main change - treat PDB violation errors during eviction as non-retryable. Sometimes the PDB can never be satisfied if we evict a pod so we'd be stuck in infinite retry. 

Additional changes:

- Fixed a bug where CAST pods were added to the eviction list twice - so they weren't evicted last correctly. 
- Changed the batching implementation with channel + workers. This does not guarantee 100% that pod operations can't get stuck but a single one won't block others (as it was before - a single infinite retry blocks all chunks after it). If we get #InfiniteRetries > #Tasks, we'd still be stuck but the chances are much lower. 
- Added some additional logging here and there for future debuggability 