### PR TITLE
KUBE-479: Adjustments to PDB

### DIFF
--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -374,7 +374,6 @@ func (h *drainNodeHandler) evictPod(ctx context.Context, pod v1.Pod, groupVersio
 			// If PDB is violated, K8S returns 429 TooManyRequests with specific cause
 			// TODO: With KUBE-479, rethink this flow in general
 			if apierrors.IsTooManyRequests(err) && apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause) {
-				h.log.Warnf("pod %s/%s failed eviction due to PodDistributionBudget violation: %v", pod.Namespace, pod.Name, err)
 				return true, err
 			}
 		}

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -372,11 +372,10 @@ func (h *drainNodeHandler) evictPod(ctx context.Context, pod v1.Pod, groupVersio
 			}
 
 			// If PDB is violated, K8S returns 429 TooManyRequests with specific cause
-			// We want to retry this case but not surface the error as it could cause forced termination to be skipped
 			// TODO: With KUBE-479, rethink this flow in general
 			if apierrors.IsTooManyRequests(err) && apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause) {
-				h.log.Warnf("pod %s/%s failed eviction due to PodDistributionBudget violation: %v", err)
-				return true, nil
+				h.log.Warnf("pod %s/%s failed eviction due to PodDistributionBudget violation: %v", pod.Namespace, pod.Name, err)
+				return true, err
 			}
 		}
 

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -372,11 +372,11 @@ func (h *drainNodeHandler) evictPod(ctx context.Context, pod v1.Pod, groupVersio
 			}
 
 			// If PDB is violated, K8S returns 429 TooManyRequests with specific cause
-			// We skip those pods since the PDB might never be satisfied and we don't want to retry forever
-			// We still want to retry for other 429 codes (like throttling)
+			// We want to retry this case but not surface the error as it could cause forced termination to be skipped
+			// TODO: With KUBE-479, rethink this flow in general
 			if apierrors.IsTooManyRequests(err) && apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause) {
 				h.log.Warnf("pod %s/%s failed eviction due to PodDistributionBudget violation: %v", err)
-				return false, nil
+				return true, nil
 			}
 		}
 

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -220,7 +220,7 @@ func (h *drainNodeHandler) sendPodsRequests(ctx context.Context, pods []v1.Pod, 
 	}
 
 	var (
-		parallelTasks = int(lo.Clamp(0.2*float64(len(pods)), 5, 20))
+		parallelTasks = int(lo.Clamp(float64(len(pods)), 30, 100))
 		taskChan      = make(chan v1.Pod, len(pods))
 		taskErrs      = make([]error, 0)
 		taskErrsMx    sync.Mutex


### PR DESCRIPTION
Adjustments to previous MR to make it more robust for the general use-case after internal discussion.

* Make PDB retryable to follow "evict-if-possible" logic for normal operations
* Bump the parallel task limit for eviction/deletion. The biggest issue with retryable PDB is that we can get stuck retrying a pod that is never satisfied; therefore losing one of the goroutines. If all get stuck, we wouldn't send eviction requests to other pods. 30 tasks should be OK for a general case since most nodes seem to have 30-100 pods in total on average from our experience. We will probably remove this limit in a future PR entirely. 