### PR TITLE
KUBE-479: Eviction adjustments 

### DIFF
--- a/actions/delete_node_handler.go
+++ b/actions/delete_node_handler.go
@@ -136,9 +136,9 @@ func (h *deleteNodeHandler) Handle(ctx context.Context, action *castai.ClusterAc
 		return h.deletePod(ctx, *deleteOptions, pod)
 	}
 
-	if err := h.sendPodsRequests(ctx, pods, deletePod); err != nil {
-		return fmt.Errorf("sending delete pods requests: %w", err)
-	}
+	deletedPods, failedPods := executeBatchPodActions(ctx, log, pods, deletePod, "delete-pod")
+	log.Infof("successfully deleted %d pods, failed to delete %d pods", len(deletedPods), len(failedPods))
+
 	if err := h.deleteNodeVolumeAttachments(ctx, req.NodeName); err != nil {
 		log.Warnf("deleting volume attachments: %v", err)
 	}

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -149,10 +149,12 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		}
 	}
 
+	// Note: if some pods remained even after forced deletion, we'd hit and return timeout here.
+	// This shouldn't happen if the pod was properly cordoned.
 	if deleteErr == nil {
 		log.Info("node drained forcefully")
 	} else {
-		log.Warnf("node failed to force drain: %w", deleteErr)
+		log.Warnf("node failed to force drain: %v", deleteErr)
 	}
 
 	return deleteErr

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -130,9 +130,12 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		var err error
 		for _, o := range options {
 			deleteCtx, deleteCancel := context.WithTimeout(ctx, h.cfg.podsDeleteTimeout)
-			defer deleteCancel()
 
 			err = h.deleteNodePods(deleteCtx, log, node, o)
+
+			// Clean-up the child context if we got here; no reason to wait for the function to exit
+			deleteCancel()
+
 			if err == nil {
 				break
 			}

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -511,3 +511,7 @@ type podFailedActionError struct {
 func (p *podFailedActionError) Error() string {
 	return fmt.Sprintf("action %q: %v", p.Action, errors.Join(p.Errors...))
 }
+
+func (p *podFailedActionError) Unwrap() []error {
+	return p.Errors
+}

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -96,13 +96,15 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		return err
 	}
 
-	log.Infof("draining node, drain_timeout_seconds=%f, force=%v created_at=%s", drainTimeout.Seconds(), req.Force, action.CreatedAt)
+	log.Info("tainting node for draining")
 
 	if err := h.taintNode(ctx, node); err != nil {
 		return fmt.Errorf("tainting node %q: %w", req.NodeName, err)
 	}
 
-	// First try to evict pods gracefully.
+	log.Infof("draining node, drain_timeout_seconds=%f, force=%v created_at=%s", drainTimeout.Seconds(), req.Force, action.CreatedAt)
+
+	// First try to evict pods gracefully using eviction API.
 	evictCtx, evictCancel := context.WithTimeout(ctx, drainTimeout)
 	defer evictCancel()
 	err = h.evictNodePods(evictCtx, log, node)

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -94,10 +94,10 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 		return err
 	}
 
-	log.Info("tainting node for draining")
+	log.Info("cordoning node for draining")
 
-	if err := h.taintNode(ctx, node); err != nil {
-		return fmt.Errorf("tainting node %q: %w", req.NodeName, err)
+	if err := h.cordonNode(ctx, node); err != nil {
+		return fmt.Errorf("cordoning node %q: %w", req.NodeName, err)
 	}
 
 	log.Infof("draining node, drain_timeout_seconds=%f, force=%v created_at=%s", drainTimeout.Seconds(), req.Force, action.CreatedAt)
@@ -158,7 +158,7 @@ func (h *drainNodeHandler) Handle(ctx context.Context, action *castai.ClusterAct
 	return deleteErr
 }
 
-func (h *drainNodeHandler) taintNode(ctx context.Context, node *v1.Node) error {
+func (h *drainNodeHandler) cordonNode(ctx context.Context, node *v1.Node) error {
 	if node.Spec.Unschedulable {
 		return nil
 	}

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -502,7 +502,7 @@ func isControlledBy(p *v1.Pod, kind string) bool {
 }
 
 type podFailedActionError struct {
-	// Action is either "delete" or "evict"
+	// Action holds context what was the code trying to do.
 	Action string
 	// Errors should hold an entry per pod, for which the action failed.
 	Errors []error

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -353,6 +353,14 @@ func (h *drainNodeHandler) listNodePodsToEvict(ctx context.Context, log logrus.F
 // This is useful when you don't expect some pods on the node to terminate (e.g. because eviction failed for them) so there is no reason to wait until timeout.
 // The wait can potentially run forever if pods are scheduled on the node and are not evicted/deleted by anything. Use a timeout to avoid infinite wait.
 func (h *drainNodeHandler) waitNodePodsTerminated(ctx context.Context, log logrus.FieldLogger, node *v1.Node, podsToIgnore []*v1.Pod) error {
+	// Check if context is cancelled before starting any work.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		// Continue with the work
+	}
+
 	podsToIgnoreLookup := make(map[string]struct{})
 	for _, pod := range podsToIgnore {
 		podsToIgnoreLookup[fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)] = struct{}{}

--- a/actions/drain_node_handler.go
+++ b/actions/drain_node_handler.go
@@ -60,12 +60,11 @@ func newDrainNodeHandler(log logrus.FieldLogger, clientset kubernetes.Interface,
 // the result is clamped between 0s and the requested timeout.
 func (h *drainNodeHandler) getDrainTimeout(action *castai.ClusterAction) time.Duration {
 	timeSinceCreated := time.Since(action.CreatedAt)
-	drainTimeout := time.Duration(action.ActionDrainNode.DrainTimeoutSeconds) * time.Second
+	requestedTimeout := time.Duration(action.ActionDrainNode.DrainTimeoutSeconds) * time.Second
 
-	// Remove 2 poll interval required for polling the action.
-	timeSinceCreated = timeSinceCreated - roundTripTime
+	drainTimeout := requestedTimeout - timeSinceCreated
 
-	return lo.Clamp(drainTimeout-timeSinceCreated, minDrainTimeout*time.Second, time.Duration(action.ActionDrainNode.DrainTimeoutSeconds)*time.Second)
+	return lo.Clamp(drainTimeout, minDrainTimeout*time.Second, requestedTimeout)
 }
 
 type drainNodeHandler struct {

--- a/actions/drain_node_handler_test.go
+++ b/actions/drain_node_handler_test.go
@@ -23,12 +23,15 @@ import (
 )
 
 func TestDrainNodeHandler(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 
 	t.Run("drain successfully", func(t *testing.T) {
+		t.Parallel()
+
 		nodeName := "node1"
 		podName := "pod1"
 		clientset := setupFakeClientWithNodePodEviction(nodeName, podName)
@@ -70,6 +73,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("skip drain when node not found", func(t *testing.T) {
+		t.Parallel()
+
 		nodeName := "node1"
 		podName := "pod1"
 		clientset := setupFakeClientWithNodePodEviction(nodeName, podName)
@@ -98,6 +103,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("when eviction fails for a pod and force=false, leaves node cordoned and skip deletion", func(t *testing.T) {
+		t.Parallel()
+
 		nodeName := "node1"
 		podName := "pod1"
 		clientset := setupFakeClientWithNodePodEviction(nodeName, podName)
@@ -133,6 +140,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("when eviction timeout is reached and force=false, leaves node cordoned and skip deletion", func(t *testing.T) {
+		t.Parallel()
+
 		nodeName := "node1"
 		podName := "pod1"
 		clientset := setupFakeClientWithNodePodEviction(nodeName, podName)
@@ -169,6 +178,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("eviction fails and force=true, force remove pods", func(t *testing.T) {
+		t.Parallel()
+
 		cases := []struct {
 			name                    string
 			drainTimeoutSeconds     int
@@ -188,6 +199,8 @@ func TestDrainNodeHandler(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				r := require.New(t)
 				nodeName := "node1"
 				podName := "pod1"
@@ -247,7 +260,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("eviction fails and force=true, at least one pod fails to delete due to internal error, should return error", func(t *testing.T) {
-		r := require.New(t)
+		t.Parallel()
+
 		nodeName := "node1"
 		podName := "pod1"
 		clientset := setupFakeClientWithNodePodEviction(nodeName, podName)
@@ -295,7 +309,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("eviction fails and force=true, timeout during deletion should be retried and returned", func(t *testing.T) {
-		r := require.New(t)
+		t.Parallel()
+
 		nodeName := "node1"
 		podName := "pod1"
 		clientset := setupFakeClientWithNodePodEviction(nodeName, podName)
@@ -345,6 +360,8 @@ func TestDrainNodeHandler(t *testing.T) {
 	})
 
 	t.Run("force=true, failed eviction for PDBs should be retried until timeout before deleting", func(t *testing.T) {
+		t.Parallel()
+
 		// tests specifically that PDB error in eviction is retried and not failed fast
 		nodeName := "node1"
 		podName := "pod1"

--- a/actions/kubernetes_helpers.go
+++ b/actions/kubernetes_helpers.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/tsdb/errors"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -201,19 +200,4 @@ type podActionFailure struct {
 	actionName string
 	pod        *v1.Pod
 	err        error
-}
-
-type batchPodActionError struct {
-	FailedPods []struct {
-		pod *v1.Pod
-		err error
-	}
-}
-
-func (b *batchPodActionError) Error() string {
-	multiErr := &errors.MultiError{}
-	for _, failedPod := range b.FailedPods {
-		multiErr.Add(fmt.Errorf("pod %s/%s failed: %w", failedPod.pod.Namespace, failedPod.pod.Namespace, failedPod.err))
-	}
-	return multiErr.Error()
 }


### PR DESCRIPTION
PR attempts to provide more consistent drain semantics (and handle some edge cases). 

Overview of changes:
1. Previously any pod that hit a non-retryable failure during eviction caused the error to surface and stop further processing. Now we will continue with forced deletion so one pod won't affect the overall flow (but we still surface an error at the end). 
2. In addition to 1), pods where DELETE/EVICT failed are not waited for termination. Otherwise we are stuck waiting for something that won't happen. 
3. For deletions, we follow the same logic as 1) - a single failed pod doesn't stop us retrying deletion ungracefully. 
4. Removed drainTimeout adjustment that was adding 10s on top (Discussed with Marcin; looks obsolete) 
5. Pods that are finished but Failed are also ignored for eviction (previously only succeeded pods were)
6. In deleteNodeHandler, if we failed to delete some pods, we still continue with the delete operation. The node is already deleted so the pods will disappear anyway, but we could skip deleting volume attachments because of that.

For drains with force=false, there should be practical changes. 

Force drains are used in three cases currently:
- Requested by user via API
- Rebalancer with graceful eviction=false (default)
- Spot interruptions

For rebalancer, we want to keep the behavior where we try to evict by respecting PDBs for the whole timeout duration (2minutes). So even if PDB is violated by eviction, we treat it as retryable case.

Following discussion with Saulius, we decided to handle Spot interruption by sending a low timeout value for eviction - cluster controller is unaware of that case and handles it as normal forced drain operation. 
