### PR TITLE
fix: auto approve csr - watch ignore contex.Canceled and clear functi…

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -281,6 +281,9 @@ func WatchCastAINodeCSRs(ctx context.Context, log logrus.FieldLogger, client kub
 		waitext.Forever,
 		func(ctx context.Context) (bool, error) {
 			w, err = getWatcher(ctx, client)
+			if errors.Is(err, context.Canceled) {
+				return false, err
+			}
 			if err != nil {
 				return true, fmt.Errorf("fail to open v1 and v1beta watching client: %w", err)
 			}
@@ -306,7 +309,8 @@ func WatchCastAINodeCSRs(ctx context.Context, log logrus.FieldLogger, client kub
 		case event, ok := <-w.ResultChan():
 			if !ok {
 				log.Debug("watcher closed")
-				WatchCastAINodeCSRs(ctx, log, client, c) // start over in case of any error
+				go WatchCastAINodeCSRs(ctx, log, client, c) // start over in case of any error
+				return
 			}
 
 			csrResult, name, request := toCertificate(event)

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -281,11 +281,13 @@ func WatchCastAINodeCSRs(ctx context.Context, log logrus.FieldLogger, client kub
 		waitext.Forever,
 		func(ctx context.Context) (bool, error) {
 			w, err = getWatcher(ctx, client)
+			// Context canceled is when the cluster-controller is stopped.
+			// In that case context.Canceled is not an error.
 			if errors.Is(err, context.Canceled) {
 				return false, err
 			}
 			if err != nil {
-				return true, fmt.Errorf("fail to open v1 and v1beta watching client: %w", err)
+				return true, fmt.Errorf("getWatcher: %w", err)
 			}
 			return false, nil
 		},


### PR DESCRIPTION
…on stack

From cluster-hub logs we sometimes gets
```
"retrying: fail to open v1 and v1beta watching client: fail to open v1 and v1beta watching client: context canceled" RunAutoApprove=auto-approve-csr
```

and also I think we should spin a new goroutin in case channel is close to remove the call stack of prev function