### PR TITLE
feat: max actions in progress

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -128,14 +128,15 @@ func runController(
 	log.Infof("running castai-cluster-controller version %v, log-level: %v", binVersion, logger.Level)
 
 	actionsConfig := controller.Config{
-		PollWaitInterval: 5 * time.Second,
-		PollTimeout:      maxRequestTimeout,
-		AckTimeout:       30 * time.Second,
-		AckRetriesCount:  3,
-		AckRetryWait:     1 * time.Second,
-		ClusterID:        cfg.ClusterID,
-		Version:          binVersion.Version,
-		Namespace:        cfg.SelfPod.Namespace,
+		PollWaitInterval:     5 * time.Second,
+		PollTimeout:          maxRequestTimeout,
+		AckTimeout:           30 * time.Second,
+		AckRetriesCount:      3,
+		AckRetryWait:         1 * time.Second,
+		ClusterID:            cfg.ClusterID,
+		Version:              binVersion.Version,
+		Namespace:            cfg.SelfPod.Namespace,
+		MaxActionsInProgress: cfg.MaxActionsInProgress,
 	}
 	healthzAction := health.NewHealthzProvider(health.HealthzCfg{HealthyPollIntervalLimit: (actionsConfig.PollWaitInterval + actionsConfig.PollTimeout) * 2, StartTimeLimit: 2 * time.Minute}, log)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,15 +18,15 @@ import (
 )
 
 type Config struct {
-	Log                  Log
-	API                  API
-	TLS                  TLS
-	Kubeconfig           string
-	KubeClient           KubeClient
-	ClusterID            string
-	PprofPort            int
-	LeaderElection       LeaderElection
-        // MaxActinsInProgress serves as a safeguard to limit the number of Goroutines in progress.
+	Log            Log
+	API            API
+	TLS            TLS
+	Kubeconfig     string
+	KubeClient     KubeClient
+	ClusterID      string
+	PprofPort      int
+	LeaderElection LeaderElection
+	// MaxActionsInProgress serves as a safeguard to limit the number of Goroutines in progress.
 	MaxActionsInProgress int
 
 	MonitorMetadataPath string `mapstructure:"monitor_metadata"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	ClusterID            string
 	PprofPort            int
 	LeaderElection       LeaderElection
+        // MaxActinsInProgress serves as a safeguard to limit the number of Goroutines in progress.
 	MaxActionsInProgress int
 
 	MonitorMetadataPath string `mapstructure:"monitor_metadata"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,15 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
+	clusterId := uuid.New().String()
 	require.NoError(t, os.Setenv("API_KEY", "abc"))
 	require.NoError(t, os.Setenv("API_URL", "api.cast.ai"))
 	require.NoError(t, os.Setenv("KUBECONFIG", "~/.kube/config"))
-	require.NoError(t, os.Setenv("CLUSTER_ID", "c1"))
+	require.NoError(t, os.Setenv("CLUSTER_ID", clusterId))
 	require.NoError(t, os.Setenv("LEADER_ELECTION_ENABLED", "true"))
 	require.NoError(t, os.Setenv("LEADER_ELECTION_NAMESPACE", "castai-agent"))
 	require.NoError(t, os.Setenv("LEADER_ELECTION_LOCK_NAME", "castai-cluster-controller"))
@@ -35,7 +37,7 @@ func TestConfig(t *testing.T) {
 		SelfPod: Pod{
 			Namespace: "castai-agent",
 		},
-		ClusterID: "c1",
+		ClusterID: clusterId,
 		LeaderElection: LeaderElection{
 			Enabled:            true,
 			LockName:           "castai-cluster-controller",
@@ -46,6 +48,7 @@ func TestConfig(t *testing.T) {
 			QPS:   25,
 			Burst: 150,
 		},
+		MaxActionsInProgress: 1000,
 	}
 
 	require.Equal(t, expected, cfg)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -194,8 +194,8 @@ func (s *Controller) startProcessing(actionID string) bool {
 		return false
 	}
 
-	if len(s.startedActions) >= s.cfg.MaxActionsInProgress {
-		s.log.Warn("too many actions in progress")
+	if inProgress := len(s.startedActions); inProgress >= s.cfg.MaxActionsInProgress {
+		s.log.Warnf("too many actions in progress %d/%d", inProgress, s.cfg.MaxActionsInProgress)
 		return false
 	}
 

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -24,12 +24,13 @@ func TestController_Run(t *testing.T) {
 	t.Parallel()
 	pollTimeout := 100 * time.Millisecond
 	cfg := Config{
-		PollWaitInterval: 10 * time.Millisecond,
-		PollTimeout:      pollTimeout,
-		AckTimeout:       1 * time.Second,
-		AckRetriesCount:  3,
-		AckRetryWait:     1 * time.Millisecond,
-		ClusterID:        uuid.New().String(),
+		PollWaitInterval:     10 * time.Millisecond,
+		PollTimeout:          pollTimeout,
+		AckTimeout:           1 * time.Second,
+		AckRetriesCount:      3,
+		AckRetryWait:         1 * time.Millisecond,
+		ClusterID:            uuid.New().String(),
+		MaxActionsInProgress: 100,
 	}
 	type fields struct {
 		cfg                  Config


### PR DESCRIPTION
Part of `KUBE-417`

The idea behind the change - safeguard on the CC to limit the amount of goroutines in progress. Currently there is no limit and CC will spawn whatever API will return. 