### PR TITLE
NOJIRA: Allow for easier local run.

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/dynamic"
@@ -323,7 +324,7 @@ func (e *logContextError) Unwrap() error {
 func runningOnGKE(clientset *kubernetes.Clientset, cfg config.Config) (isGKE bool, err error) {
 	err = waitext.Retry(context.Background(), waitext.DefaultExponentialBackoff(), 3, func(ctx context.Context) (bool, error) {
 		node, err := clientset.CoreV1().Nodes().Get(ctx, cfg.SelfPod.Node, metav1.GetOptions{})
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return true, fmt.Errorf("getting node: %w", err)
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,7 +127,9 @@ func Get() Config {
 	}
 
 	if cfg.SelfPod.Namespace == "" {
-		required("LEADER_ELECTION_NAMESPACE")
+		// LEADER_ELECTION_NAMESPACE exists for backwards compatibility.
+		// But we use the namespace even without leader election so it's required.
+		required("self_pod.namespace or LEADER_ELECTION_NAMESPACE")
 	}
 
 	if cfg.LeaderElection.Enabled {


### PR DESCRIPTION
- Made `Node` not required so one can run on local machine
- Adjusted namespace error because it was confusing that you need `LEADER_ELECTION_NAMESPACE` even when not using leader election. It's still used by components so I left it as required. 