### PR TITLE
Kube-984: loadtesting in cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,5 @@ generate-e2e-client:
 	go generate ./e2e/client
 .PHONY: generate-e2e-client
 
-# TODO: Make this less simplistic
-run-loadtest:
-	# TODO: Required because of reusing config
-	API_KEY=dummy API_URL=http://example.com CLUSTER_ID=D30A163C-C5DF-4CC8-985C-D1449398295E KUBECONFIG=~/.kube/config LOG_LEVEL=4 go run . test-server
+deploy-loadtest: release
+	IMAGE_REPOSITORY=$(DOCKER_REPOSITORY) IMAGE_TAG=$(VERSION) ./hack/loadtest/deploy.sh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ API_KEY=your-api-key \
 API_URL=your-api-url \
 CLUSTER_ID=your-cluster-id \
 KUBECONFIG=path-to-kubeconfig \
+self_pod.namespace=castai-agent \
 go run .
 ```
 

--- a/hack/loadtest/deploy.sh
+++ b/hack/loadtest/deploy.sh
@@ -1,3 +1,13 @@
+#!/usr/bin/env bash
+
+CC_IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-us-docker.pkg.dev/castai-hub/library/cluster-controller}"
+CC_IMAGE_TAG="${IMAGE_TAG:-latest}"
+DEPLOY_CLUSTER_CONTROLLER="${DEPLOY_CLUSTER_CONTROLLER:-true}"
+
+# Determine the directory where the script resides.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Deploying kwok"
 helm repo add kwok https://kwok.sigs.k8s.io/charts/
 helm repo update kwok
 
@@ -5,16 +15,17 @@ helm upgrade --namespace castai-agent --create-namespace  --install kwok kwok/kw
 helm upgrade --namespace castai-agent --create-namespace  --install kwok-stages kwok/stage-fast
 helm upgrade --namespace castai-agent --create-namespace  --install kwok-metrics kwok/metrics-usage
 
-# TODO: Tune kwok to be faster?
+if [ "$DEPLOY_CLUSTER_CONTROLLER" = "true" ]; then
+  echo "Deploying cluster controller"
+  helm upgrade --namespace castai-agent --create-namespace --install  cluster-controller castai-helm/castai-cluster-controller \
+    --set castai.apiKey="dummy" \
+    --set castai.apiURL="http://castai-loadtest-agent-service.castai-agent.svc.cluster.local.:8080" \
+    --set castai.clusterID="00000000-0000-0000-0000-000000000000" \
+    --set image.repository="$CC_IMAGE_REPOSITORY" \
+    --set image.tag="$CC_IMAGE_TAG" \
+    --set image.pullPolicy="Always" \
+    --set autoscaling.enabled="true"
+fi
 
-
-helm upgrade --namespace castai-agent --create-namespace --install  cluster-controller castai-helm/castai-cluster-controller \
-  --set castai.apiKey="dummy" \
-  --set castai.apiURL="http://castai-loadtest-agent-service.castai-agent.svc.cluster.local.:8080" \
-  --set castai.clusterID="00000000-0000-0000-0000-000000000000" \
-  --set image.repository=docker.io/lachezarcast/cluster-controller \
-  --set image.tag="loadtest" \
-  --set image.pullPolicy="Always" \
-  --set autoscaling.enabled="true"
-
-kubectl apply -k . # TODO
+echo "Deploying load testing components"
+kubectl apply -k "$SCRIPT_DIR"

--- a/hack/loadtest/deploy.sh
+++ b/hack/loadtest/deploy.sh
@@ -17,10 +17,4 @@ helm upgrade --namespace castai-agent --create-namespace --install  cluster-cont
   --set image.pullPolicy="Always" \
   --set autoscaling.enabled="true"
 
-
-
-# Config for load test server
-# Config for prometheus
-# Config for grafana?
-
-# Kwok !
+kubectl apply -k . # TODO

--- a/hack/loadtest/deploy.sh
+++ b/hack/loadtest/deploy.sh
@@ -2,6 +2,8 @@
 
 CC_IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-us-docker.pkg.dev/castai-hub/library/cluster-controller}"
 CC_IMAGE_TAG="${IMAGE_TAG:-latest}"
+LOAD_TEST_IMAGE_REPOSITORY="${LOAD_TEST_IMAGE_REPOSITORY:-$CC_IMAGE_REPOSITORY}"
+LOAD_TEST_IMAGE_TAG="${LOAD_TEST_IMAGE_TAG:-$CC_IMAGE_TAG}"
 DEPLOY_CLUSTER_CONTROLLER="${DEPLOY_CLUSTER_CONTROLLER:-true}"
 
 # Determine the directory where the script resides.
@@ -28,4 +30,6 @@ if [ "$DEPLOY_CLUSTER_CONTROLLER" = "true" ]; then
 fi
 
 echo "Deploying load testing components"
-kubectl apply -k "$SCRIPT_DIR"
+kubectl kustomize "$SCRIPT_DIR" | \
+  LOADTEST_REPOSITORY="$LOAD_TEST_IMAGE_REPOSITORY" LOADTEST_TAG="$LOAD_TEST_IMAGE_TAG" envsubst \$LOADTEST_REPOSITORY,\$LOADTEST_TAG | \
+  kubectl apply -f -

--- a/hack/loadtest/deploy.sh
+++ b/hack/loadtest/deploy.sh
@@ -1,14 +1,14 @@
 helm repo add kwok https://kwok.sigs.k8s.io/charts/
 helm repo update kwok
 
-helm upgrade --namespace castai-agent --install kwok kwok/kwok
-helm upgrade --namespace castai-agent --install kwok-stages kwok/stage-fast
-helm upgrade --namespace castai-agent --install kwok-metrics kwok/metrics-usage
+helm upgrade --namespace castai-agent --create-namespace  --install kwok kwok/kwok
+helm upgrade --namespace castai-agent --create-namespace  --install kwok-stages kwok/stage-fast
+helm upgrade --namespace castai-agent --create-namespace  --install kwok-metrics kwok/metrics-usage
 
 # TODO: Tune kwok to be faster?
 
 
-helm upgrade --namespace castai-agent --install  cluster-controller castai-helm/castai-cluster-controller \
+helm upgrade --namespace castai-agent --create-namespace --install  cluster-controller castai-helm/castai-cluster-controller \
   --set castai.apiKey="dummy" \
   --set castai.apiURL="http://castai-loadtest-agent-service.castai-agent.svc.cluster.local.:8080" \
   --set castai.clusterID="00000000-0000-0000-0000-000000000000" \

--- a/hack/loadtest/deploy.sh
+++ b/hack/loadtest/deploy.sh
@@ -1,0 +1,26 @@
+helm repo add kwok https://kwok.sigs.k8s.io/charts/
+helm repo update kwok
+
+helm upgrade --namespace castai-agent --install kwok kwok/kwok
+helm upgrade --namespace castai-agent --install kwok-stages kwok/stage-fast
+helm upgrade --namespace castai-agent --install kwok-metrics kwok/metrics-usage
+
+# TODO: Tune kwok to be faster?
+
+
+helm upgrade --namespace castai-agent --install  cluster-controller castai-helm/castai-cluster-controller \
+  --set castai.apiKey="dummy" \
+  --set castai.apiURL="http://castai-loadtest-agent-service.castai-agent.svc.cluster.local.:8080" \
+  --set castai.clusterID="00000000-0000-0000-0000-000000000000" \
+  --set image.repository=docker.io/lachezarcast/cluster-controller \
+  --set image.tag="loadtest" \
+  --set image.pullPolicy="Always" \
+  --set autoscaling.enabled="true"
+
+
+
+# Config for load test server
+# Config for prometheus
+# Config for grafana?
+
+# Kwok !

--- a/hack/loadtest/grafana/cluster-controller-dashboard.json
+++ b/hack/loadtest/grafana/cluster-controller-dashboard.json
@@ -1,0 +1,1104 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(action_executed_total[$__rate_interval])) by (type)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Actions/s executed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (type, success) (rate(action_executed_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Actions execute",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 16,
+      "panels": [],
+      "title": "CPU",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(process_cpu_seconds_total[5m]) * 100",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU utilization %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "go_goroutines{}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "go_threads",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OS threads allocated",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Memory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "go_memstats_alloc_bytes / (1024*1024)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total MB allocated",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "go_memstats_heap_alloc_bytes / (1024*1024)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heap allocated MB",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(go_memstats_alloc_bytes_total[$__rate_interval]) / (1024)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rate of memory allocated (KB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "go_memstats_heap_objects",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heap objects count",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 9,
+      "panels": [],
+      "title": "GC",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "increase(go_gc_duration_seconds_count[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC cycles count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(go_gc_duration_seconds_sum[5m]) / rate(go_gc_duration_seconds_count[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC pause duration",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Cluster controller",
+  "uid": "aegw4usai4oowf",
+  "version": 1,
+  "weekStart": ""
+}

--- a/hack/loadtest/grafana/cluster-controller-dashboard.json
+++ b/hack/loadtest/grafana/cluster-controller-dashboard.json
@@ -71,10 +71,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -85,95 +81,6 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "sum(rate(action_executed_total[$__rate_interval])) by (type)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Actions/s executed",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
         "y": 0
       },
       "id": 1,
@@ -209,7 +116,7 @@
           "refId": "A"
         }
       ],
-      "title": "Actions execute",
+      "title": "Actions executed",
       "type": "timeseries"
     },
     {
@@ -565,8 +472,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -658,8 +564,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -751,8 +656,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -844,8 +748,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -950,8 +853,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1043,8 +945,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",

--- a/hack/loadtest/grafana/dashboards-config.yaml
+++ b/hack/loadtest/grafana/dashboards-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/hack/loadtest/grafana/grafana.ini
+++ b/hack/loadtest/grafana/grafana.ini
@@ -1,0 +1,6 @@
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+org_role = Admin

--- a/hack/loadtest/grafana/prometheus-datasource.yaml
+++ b/hack/loadtest/grafana/prometheus-datasource.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090
+    isDefault: true

--- a/hack/loadtest/kustomization.yaml
+++ b/hack/loadtest/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - loadtest-components.yaml
+
+configMapGenerator:
+  - name: grafana-config
+    namespace: castai-agent
+    files:
+      - cluster-controller-dashboard.json=./grafana/cluster-controller-dashboard.json
+      - grafana.ini=./grafana/grafana.ini
+      - dashboards.yaml=./grafana/dashboards-config.yaml
+      - datasource.yaml=./grafana/prometheus-datasource.yaml

--- a/hack/loadtest/loadtest-components.yaml
+++ b/hack/loadtest/loadtest-components.yaml
@@ -57,7 +57,7 @@ metadata:
 data:
   prometheus.yml: |
     global:
-      scrape_interval: 15s
+      scrape_interval: 5s
     scrape_configs:
       - job_name: 'cluster-controller'
         kubernetes_sd_configs:
@@ -75,46 +75,6 @@ data:
             regex: ([^:]+)(?::\d+)?
             target_label: __address__
             replacement: $1:9090
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: grafana-config
-  namespace: castai-agent
-data:
-  datasource.yaml: |
-    apiVersion: 1
-    datasources:
-      - name: Prometheus
-        type: prometheus
-        access: proxy
-        url: http://localhost:9090
-        isDefault: true
-  grafana.ini: |
-    [auth]
-    disable_login_form = true
-
-    [auth.anonymous]
-    enabled = true
-    org_role = Admin
-  dashboards.yaml: |
-    apiVersion: 1
-    providers:
-      - name: 'default'
-        orgId: 1
-        folder: ''
-        type: file
-        options:
-          path: /var/lib/grafana/dashboards
-  cc-dashboard.json: |
-    {
-      "annotations": {
-        "list": []
-      },
-      "panels": [],
-      "title": "Cluster controller",
-      "version": 1
-    }
 ---
 apiVersion: v1
 kind: Service
@@ -167,7 +127,8 @@ spec:
           volumeMounts:
             # Mount the datasource provisioning
             - name: grafana-config
-              mountPath: /etc/grafana/provisioning/datasources
+              mountPath: /etc/grafana/provisioning/datasources/datasource.yaml
+              subPath: datasource.yaml
             # Mount the custom grafana.ini to disable login and enable anonymous access
             - name: grafana-config
               mountPath: /etc/grafana/grafana.ini
@@ -176,10 +137,10 @@ spec:
             - name: grafana-config
               mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
               subPath: dashboards.yaml
-            # Mount the pre-created dashboards JSON files
+            # Mount the pre-created dashboards JSON file
             - name: grafana-config
-              mountPath: /var/lib/grafana/dashboards/cc-dashboard.json
-              subPath: cc-dashboard.json
+              mountPath: /var/lib/grafana/dashboards/cluster-controller-dashboard.json
+              subPath: cluster-controller-dashboard.json
       volumes:
         - name: prometheus-config-volume
           configMap:

--- a/hack/loadtest/loadtest-components.yaml
+++ b/hack/loadtest/loadtest-components.yaml
@@ -18,6 +18,38 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-sa
+  namespace: castai-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-sa
+    namespace: castai-agent
+roleRef:
+  kind: ClusterRole
+  name: prometheus-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
@@ -28,21 +60,74 @@ data:
       scrape_interval: 15s
     scrape_configs:
       - job_name: 'cluster-controller'
-        static_configs:
-          - targets: ['localhost:9090']
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - castai-agent
+        relabel_configs:
+          # Filter targets based on a deployment label.
+          - source_labels: [ __meta_kubernetes_pod_label_app_kubernetes_io_name ]
+            action: keep
+            regex: castai-cluster-controller
+          # Explicitly set the scrape port to 9090 as this is what CC uses.
+          - source_labels: [ __address__ ]
+            regex: ([^:]+)(?::\d+)?
+            target_label: __address__
+            replacement: $1:9090
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana-service
+  name: observability-service
   namespace: castai-agent
 spec:
   selector:
-    app: monitored-app
+    app: simple-observability
   ports:
     - protocol: TCP
       port: 3000
       targetPort: 3000
+      name: grafana
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090
+      name: prometheus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-observability
+  namespace: castai-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: simple-observability
+  template:
+    metadata:
+      labels:
+        app: simple-observability
+    spec:
+      serviceAccountName: prometheus-sa
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,19 +146,6 @@ spec:
     spec:
       serviceAccountName: castai-loadtest-agent-sa
       containers:
-        - name: prometheus-sidecar
-          image: prom/prometheus:latest
-          args:
-            - "--config.file=/etc/prometheus/prometheus.yml"
-          ports:
-            - containerPort: 9091
-          volumeMounts:
-            - name: prometheus-config-volume
-              mountPath: /etc/prometheus
-        - name: grafana
-          image: grafana/grafana:latest
-          ports:
-            - containerPort: 3000
         - name: castai-agent
           image: docker.io/lachezarcast/cluster-controller:loadtest2 # TODO!
           imagePullPolicy: Always
@@ -85,10 +157,6 @@ spec:
           env:
             - name: PORT
               value: "8080"
-      volumes:
-        - name: prometheus-config-volume
-          configMap:
-            name: prometheus-config
 ---
 apiVersion: v1
 kind: Service
@@ -99,12 +167,6 @@ spec:
   selector:
     app: castai-loadtest-agent
   ports:
-    - name: prometheus
-      port: 9091
-      targetPort: 9091
-    - name: grafana
-      port: 3000
-      targetPort: 3000
     - name: loadtest
       port: 8080
       targetPort: 8080

--- a/hack/loadtest/loadtest-components.yaml
+++ b/hack/loadtest/loadtest-components.yaml
@@ -167,7 +167,7 @@ spec:
       serviceAccountName: castai-loadtest-agent-sa
       containers:
         - name: castai-agent
-          image: docker.io/lachezarcast/cluster-controller:loadtest2 # TODO!
+          image: ${LOADTEST_REPOSITORY}:${LOADTEST_TAG}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/hack/loadtest/loadtest-components.yaml
+++ b/hack/loadtest/loadtest-components.yaml
@@ -77,6 +77,46 @@ data:
             replacement: $1:9090
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-config
+  namespace: castai-agent
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://localhost:9090
+        isDefault: true
+  grafana.ini: |
+    [auth]
+    disable_login_form = true
+
+    [auth.anonymous]
+    enabled = true
+    org_role = Admin
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: 'default'
+        orgId: 1
+        folder: ''
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+  cc-dashboard.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "panels": [],
+      "title": "Cluster controller",
+      "version": 1
+    }
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: observability-service
@@ -124,10 +164,29 @@ spec:
           image: grafana/grafana:latest
           ports:
             - containerPort: 3000
+          volumeMounts:
+            # Mount the datasource provisioning
+            - name: grafana-config
+              mountPath: /etc/grafana/provisioning/datasources
+            # Mount the custom grafana.ini to disable login and enable anonymous access
+            - name: grafana-config
+              mountPath: /etc/grafana/grafana.ini
+              subPath: grafana.ini
+            # Mount the dashboards provisioning file
+            - name: grafana-config
+              mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
+              subPath: dashboards.yaml
+            # Mount the pre-created dashboards JSON files
+            - name: grafana-config
+              mountPath: /var/lib/grafana/dashboards/cc-dashboard.json
+              subPath: cc-dashboard.json
       volumes:
         - name: prometheus-config-volume
           configMap:
             name: prometheus-config
+        - name: grafana-config
+          configMap:
+            name: grafana-config
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/hack/loadtest/loadtest-components.yaml
+++ b/hack/loadtest/loadtest-components.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: castai-loadtest-agent-sa
+  namespace: castai-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: castai-agent-cluster-admin-binding
+subjects:
+  - kind: ServiceAccount
+    name: castai-loadtest-agent-sa
+    namespace: castai-agent
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: castai-agent
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'cluster-controller'
+        static_configs:
+          - targets: ['localhost:9090']
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+  namespace: castai-agent
+spec:
+  selector:
+    app: monitored-app
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: castai-loadtest-agent
+  namespace: castai-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: castai-loadtest-agent
+  template:
+    metadata:
+      labels:
+        app: castai-loadtest-agent
+    spec:
+      serviceAccountName: castai-loadtest-agent-sa
+      containers:
+        - name: prometheus-sidecar
+          image: prom/prometheus:latest
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          ports:
+            - containerPort: 9091
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+        - name: castai-agent
+          image: docker.io/lachezarcast/cluster-controller:loadtest2 # TODO!
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          command:
+            - "castai-cluster-controller"
+            - "test-server"
+          env:
+            - name: PORT
+              value: "8080"
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: castai-loadtest-agent-service
+  namespace: castai-agent
+spec:
+  selector:
+    app: castai-loadtest-agent
+  ports:
+    - name: prometheus
+      port: 9091
+      targetPort: 9091
+    - name: grafana
+      port: 3000
+      targetPort: 3000
+    - name: loadtest
+      port: 8080
+      targetPort: 8080

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -5,7 +5,11 @@ Load test requires 3 components:
 - Kwok controller to simulate nodes/pods
 - Cluster controller itself.
 
-Right now this is extremely basic and you have to run those manually locally.
+Optionally, observability stack helps identify problems with the deployment.
+
+## Local run
+This runs all 3 components as local processes against a cluster. 
+Useful for debugging. https://github.com/arl/statsviz can be used for local observability.
 
 Start kwok:
 ```
@@ -26,3 +30,16 @@ After starting, start cluster controller with some dummy values and point it to 
 ```
 API_KEY=dummy API_URL=http://localhost:8080 CLUSTER_ID=D30A163C-C5DF-4CC8-985C-D1449398295E KUBECONFIG=~/.kube/config LOG_LEVEL=4 LEADER_ELECTION_NAMESPACE=default METRICS_ENABLED=true go run .                     
 ```
+
+## Deployment in cluster
+Running the command below will build the local cluster controller, push it to a repository and deploy all 3 required components + observability stack into the current cluster.
+Both the cluster controller and the test server will use the same image but will run in different modes. 
+
+`make deploy-loadtest DOCKER_REPOSITORY=<repository_for_iamge> VERSION=<tag> ARCH=amd64`
+
+If you wish to skip deploying cluster controller, prefix make with `DEPLOY_CLUSTER_CONTROLLER=false`. Be sure to update the existing cluster controller to use the deployed test server's URL.
+
+If you wish to use different repository for cluster controller and for test server, pass `LOAD_TEST_IMAGE_REPOSITORY` and `LOAD_TEST_IMAGE_TAG` env vars to the command.
+
+The deploy command also includes prometheus and grafana. 
+Use `kubectl port-forward -n castai-agent svc/observability-service 3000:3000` to reach the grafana instance. There is already a preconfigured dashboard available on the instance.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -11,7 +11,7 @@ Start kwok:
 ```
  kwok --kubeconfig=~/.kube/config \
     --manage-all-nodes=false \
-    --manage-nodes-with-annotation-selector=kwok.x-k8s.io/node=fake-node \
+    --manage-nodes-with-annotation-selector=kwok.x-k8s.io/node=fake \
     --node-lease-duration-seconds=40 \
     --cidr=10.0.0.1/24 \
     --node-ip=10.0.0.1

--- a/loadtest/scenarios/k8s_objects.go
+++ b/loadtest/scenarios/k8s_objects.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	DefaultKwokMarker = "kwok.x-k8s.io/node"
-	KwokMarkerValue   = "fake-node"
+	KwokMarkerValue   = "fake"
 )
 
 type KwokConfig struct {
@@ -71,12 +71,12 @@ func NewKwokNode(cfg KwokConfig, nodeName string) *corev1.Node {
 		},
 		Status: corev1.NodeStatus{
 			Allocatable: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewMilliQuantity(32, resource.DecimalSI),
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(4000, resource.DecimalSI),
 				corev1.ResourceMemory: *resource.NewQuantity(256*1024*1024*1024, resource.BinarySI),
 				corev1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
 			},
 			Capacity: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewMilliQuantity(32, resource.DecimalSI),
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(4000, resource.DecimalSI),
 				corev1.ResourceMemory: *resource.NewQuantity(256*1024*1024*1024, resource.BinarySI),
 				corev1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
 			},


### PR DESCRIPTION
Adds the option to deploy CC + test server + kwok + observability stack in existing cluster, no need to manually run them locally. 

The deploy consists of:
- Cluster controller (via helm install), can be omitted
- Kwok controller (via helm install)
- Deployment for the test server (CC is already wired to use it)
- Deployment for prometheus/grafana, configured to scrape CC endpoint 
- RBAC for prometheus and test-server. 

Grafana also has preconfigured dashboards with several metrics, more can be added (should update the dashboard json under `hack/loadtest/grafana`:


<img width="1881" alt="image" src="https://github.com/user-attachments/assets/ca4520e2-ebe9-4ba7-95ae-a8c99d825f51" />


<img width="1870" alt="image" src="https://github.com/user-attachments/assets/9fc86608-92d9-4f6b-9c18-241e0f3261a7" />
