### PR TITLE
KUBE-627: Avoid data race panic in logexporter

### DIFF
--- a/internal/castai/client.go
+++ b/internal/castai/client.go
@@ -126,16 +126,6 @@ func createTLSConfig(ca string) (*tls.Config, error) {
 }
 
 func (c *Client) SendLog(ctx context.Context, e *LogEntry) error {
-	// Server expects fields values to be strings. If they're not it fails with BAD_REQUEST/400.
-	// Alternatively we could use "google/protobuf/any.proto" on server side but ATM it doesn't work.
-	for k, v := range e.Fields {
-		switch v.(type) {
-		case string:
-		// do nothing
-		default:
-			e.Fields[k] = fmt.Sprint(v) // Force into string
-		}
-	}
 	resp, err := c.rest.R().
 		SetBody(e).
 		SetContext(ctx).


### PR DESCRIPTION
Copies the logrus struct before calling our hook concurrently. 

This avoids a data race when we overwrite some map items in-place while logrus is reading the map. It also avoids a rarer data race where we read the `Message` on the entry while logrus' `TextFormatter` writes to it. 

First issue causes panics under load (concurrent map read/write), second one was more benign. 

Tested using `GORACE=halt_on_error=1 log_path=race.log" go run -race .` - no errors reported. 

Race.log before change when running with `GORACE=halt_on_error=1 log_path=race.log" go run -race .`:

```
==================
WARNING: DATA RACE
Read at 0x00c000272658 by goroutine 66:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:96 +0x190
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:78 +0x80
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.gowrap1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:79 +0x44

Previous write at 0x00c000272658 by main goroutine:
  github.com/sirupsen/logrus.(*TextFormatter).printColored()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:263 +0x244
  github.com/sirupsen/logrus.(*TextFormatter).Format()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:203 +0x1094
  github.com/sirupsen/logrus.(*Entry).write()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0xf4
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x794
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194

Goroutine 66 (running) created at:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:76 +0x138
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/hooks.go:28 +0xa8
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:280 +0x29c
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:242 +0x674
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194
==================
```

When running with `halt_on_error=0`, collects all races detected (omitted most as they are duplicates though): 

```
==================
WARNING: DATA RACE
Read at 0x00c0002b89d8 by goroutine 66:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:96 +0x190
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:78 +0x80
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.gowrap1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:79 +0x44

Previous write at 0x00c0002b89d8 by main goroutine:
  github.com/sirupsen/logrus.(*TextFormatter).printColored()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:263 +0x244
  github.com/sirupsen/logrus.(*TextFormatter).Format()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:203 +0x1094
  github.com/sirupsen/logrus.(*Entry).write()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0xf4
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x794
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194

Goroutine 66 (running) created at:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:76 +0x138
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/hooks.go:28 +0xa8
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:280 +0x29c
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:242 +0x674
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194
==================
==================
WARNING: DATA RACE
Write at 0x00c000152390 by goroutine 66:
  runtime.mapaccess2()
      /opt/homebrew/opt/go/libexec/src/internal/runtime/maps/runtime_swiss.go:117 +0x2dc
  github.com/castai/cluster-controller/internal/castai.(*Client).SendLog()
      /Users/lachezar/Src/cluster-controller/internal/castai/client.go:136 +0x1a8
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:102 +0x68
  github.com/castai/cluster-controller/internal/waitext.Retry()
      /Users/lachezar/Src/cluster-controller/internal/waitext/extensions.go:71 +0x64
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:101 +0x330
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:78 +0x80
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.gowrap1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:79 +0x44

Previous read at 0x00c000152390 by main goroutine:
  runtime.(*notInHeap).add()
      /opt/homebrew/opt/go/libexec/src/runtime/malloc.go:2055 +0xc
  github.com/sirupsen/logrus.(*TextFormatter).Format()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:135 +0xd8
  github.com/sirupsen/logrus.(*Entry).write()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0xf4
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x794
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194

Goroutine 66 (running) created at:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:76 +0x138
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/hooks.go:28 +0xa8
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:280 +0x29c
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:242 +0x674
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194
==================
==================
WARNING: DATA RACE
Write at 0x00c00068a758 by goroutine 66:
  github.com/castai/cluster-controller/internal/castai.(*Client).SendLog()
      /Users/lachezar/Src/cluster-controller/internal/castai/client.go:136 +0x1b4
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:102 +0x68
  github.com/castai/cluster-controller/internal/waitext.Retry()
      /Users/lachezar/Src/cluster-controller/internal/waitext/extensions.go:71 +0x64
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:101 +0x330
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:78 +0x80
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.gowrap1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:79 +0x44

Previous read at 0x00c00068a758 by main goroutine:
  github.com/sirupsen/logrus.(*TextFormatter).Format()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:135 +0x144
  github.com/sirupsen/logrus.(*Entry).write()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0xf4
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x794
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194

Goroutine 66 (running) created at:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:76 +0x138
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/hooks.go:28 +0xa8
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:280 +0x29c
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:242 +0x674
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0xfb8
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:131 +0xf30
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194
==================
==================
WARNING: DATA RACE
Read at 0x00c0002b8a48 by goroutine 69:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:96 +0x190
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:78 +0x80
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.gowrap1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:79 +0x44

Previous write at 0x00c0002b8a48 by main goroutine:
  github.com/sirupsen/logrus.(*TextFormatter).printColored()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:263 +0x244
  github.com/sirupsen/logrus.(*TextFormatter).Format()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:203 +0x1094
  github.com/sirupsen/logrus.(*Entry).write()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0xf4
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x794
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0x198
  github.com/castai/cluster-controller/cmd/controller.saveMetadata()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:358 +0x114
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:201 +0x1624
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194

Goroutine 69 (running) created at:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:76 +0x138
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/hooks.go:28 +0xa8
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:280 +0x29c
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:242 +0x674
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0x198
  github.com/castai/cluster-controller/cmd/controller.saveMetadata()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:358 +0x114
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:201 +0x1624
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194
==================
==================
WARNING: DATA RACE
Write at 0x00c000152720 by goroutine 69:
  runtime.mapaccess2()
      /opt/homebrew/opt/go/libexec/src/internal/runtime/maps/runtime_swiss.go:117 +0x2dc
  github.com/castai/cluster-controller/internal/castai.(*Client).SendLog()
      /Users/lachezar/Src/cluster-controller/internal/castai/client.go:136 +0x1a8
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:102 +0x68
  github.com/castai/cluster-controller/internal/waitext.Retry()
      /Users/lachezar/Src/cluster-controller/internal/waitext/extensions.go:71 +0x64
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).sendLogEvent()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:101 +0x330
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.func1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:78 +0x80
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire.gowrap1()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:79 +0x44

Previous read at 0x00c000152720 by main goroutine:
  runtime.(*notInHeap).add()
      /opt/homebrew/opt/go/libexec/src/runtime/malloc.go:2055 +0xc
  github.com/sirupsen/logrus.(*TextFormatter).Format()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/text_formatter.go:135 +0xd8
  github.com/sirupsen/logrus.(*Entry).write()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0xf4
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x794
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0x198
  github.com/castai/cluster-controller/cmd/controller.saveMetadata()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:358 +0x114
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:201 +0x1624
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194

Goroutine 69 (running) created at:
  github.com/castai/cluster-controller/internal/controller/logexporter.(*LogExporter).Fire()
      /Users/lachezar/Src/cluster-controller/internal/controller/logexporter/logexporter.go:76 +0x138
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/hooks.go:28 +0xa8
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:280 +0x29c
  github.com/sirupsen/logrus.(*Entry).log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:242 +0x674
  github.com/sirupsen/logrus.(*Entry).Log()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x80
  github.com/sirupsen/logrus.(*Entry).Logf()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:349 +0xbc
  github.com/sirupsen/logrus.(*Entry).Infof()
      /Users/lachezar/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:362 +0x198
  github.com/castai/cluster-controller/cmd/controller.saveMetadata()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:358 +0x114
  github.com/castai/cluster-controller/cmd/controller.runController()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:201 +0x1624
  github.com/castai/cluster-controller/cmd/controller.run()
      /Users/lachezar/Src/cluster-controller/cmd/controller/run.go:62 +0x624
  github.com/castai/cluster-controller/cmd.init.0.NewCmd.func1()
      /Users/lachezar/Src/cluster-controller/cmd/controller/command.go:13 +0x2c
  github.com/spf13/cobra.(*Command).execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xb94
  github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x4b0
  github.com/spf13/cobra.(*Command).Execute()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x374
  github.com/spf13/cobra.(*Command).ExecuteContext()
      /Users/lachezar/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x370
  github.com/castai/cluster-controller/cmd.Execute()
      /Users/lachezar/Src/cluster-controller/cmd/root.go:36 +0x314
  main.main()
      /Users/lachezar/Src/cluster-controller/main.go:27 +0x194
==================
```
