### PR TITLE
NOJIRA Less frequent checks after EvictPod action

### DIFF
--- a/internal/actions/types.go
+++ b/internal/actions/types.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/castai/cluster-controller/internal/castai"
 )
@@ -25,4 +26,12 @@ func newUnexpectedTypeErr(value, expectedType interface{}) error {
 
 type ActionHandler interface {
 	Handle(ctx context.Context, action *castai.ClusterAction) error
+}
+
+type PodPhaseError struct {
+	Phase corev1.PodPhase
+}
+
+func (e PodPhaseError) Error() string {
+	return fmt.Sprintf("pod is in phase %s", e.Phase)
 }


### PR DESCRIPTION
We get a little bit of warning spam when pods are getting evicted through this action. Since this is a normal condition, we can probably check it less frequently and treat it as an info message. I picked 5 seconds arbitrarily, it's not clear how long pod shutdown takes typically.