### PR TITLE
CO-3733 Support timeout for EvictPod

### DIFF
--- a/internal/castai/types.go
+++ b/internal/castai/types.go
@@ -160,8 +160,9 @@ type ActionDrainNode struct {
 }
 
 type ActionEvictPod struct {
-	Namespace string `json:"namespace"`
-	PodName   string `json:"podName"`
+	Namespace      string `json:"namespace"`
+	PodName        string `json:"podName"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
 }
 
 type ActionPatchNode struct {


### PR DESCRIPTION
In cases where we cannot evict pods (i.e. due to restrictive PDBs), we don't want these actions pending indefinitely.