### PR TITLE
CSU-3481: Add new bootstrap requesting user for CSR to auto-approval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(GOLANGCI_LINT):
 
 ## build: Build the binary for the specified architecture and create a Docker image. Usually this means ARCH=amd64 should be set if running on an ARM machine. Use `go build .` for simple local build.
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -ldflags "-s -w -X main.Version=v100.100.100" -o bin/castai-cluster-controller-$(ARCH) .
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -ldflags "-s -w" -o bin/castai-cluster-controller-$(ARCH) .
 	docker build --platform=linux/$(ARCH) --build-arg TARGETARCH=$(ARCH) -t $(DOCKER_REPOSITORY):$(VERSION) .
 
 push:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(GOLANGCI_LINT):
 
 ## build: Build the binary for the specified architecture and create a Docker image. Usually this means ARCH=amd64 should be set if running on an ARM machine. Use `go build .` for simple local build.
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -ldflags "-s -w" -o bin/castai-cluster-controller-$(ARCH) .
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -ldflags "-s -w -X main.Version=v100.100.100" -o bin/castai-cluster-controller-$(ARCH) .
 	docker build --platform=linux/$(ARCH) --build-arg TARGETARCH=$(ARCH) -t $(DOCKER_REPOSITORY):$(VERSION) .
 
 push:

--- a/internal/actions/csr/svc.go
+++ b/internal/actions/csr/svc.go
@@ -241,7 +241,7 @@ func shouldSkip(csr *wrapper.CSR) (bool, string) {
 		return true, fmt.Sprintf("csr requesting user is not managed by CAST AI: %s", csr.RequestingUser())
 	}
 	if !managerSubjectCommonName(csr.ParsedCertificateRequest().Subject.CommonName) {
-		return true, fmt.Sprintf("csr common name is not managed by CAST AIL %s", csr.ParsedCertificateRequest().Subject.CommonName)
+		return true, fmt.Sprintf("csr common name is not managed by CAST AI %s", csr.ParsedCertificateRequest().Subject.CommonName)
 	}
 	return false, ""
 }

--- a/internal/actions/csr/svc.go
+++ b/internal/actions/csr/svc.go
@@ -24,12 +24,15 @@ import (
 )
 
 const (
-	approveCSRTimeout              = 4 * time.Minute
-	groupSystemNodesName           = "system:nodes"
+	approveCSRTimeout    = 4 * time.Minute
+	groupSystemNodesName = "system:nodes"
+	// kubeletBootstrapRequestingUser is the observed requestor for node's CSRs from real GKE clusters.
 	kubeletBootstrapRequestingUser = "kubelet-bootstrap"
-	clusterControllerSAName        = "system:serviceaccount:castai-agent:castai-cluster-controller"
-	approvedMessage                = "This CSR was approved by CAST AI"
-	csrOutdatedAfter               = time.Hour
+	// kubeletNodepoolBootstrapRequestingUser is the observed requestor for node's CSRs for GKE clusters 1.33+.
+	kubeletNodepoolBootstrapRequestingUser = "kubelet-nodepool-bootstrap"
+	clusterControllerSAName                = "system:serviceaccount:castai-agent:castai-cluster-controller"
+	approvedMessage                        = "This CSR was approved by CAST AI"
+	csrOutdatedAfter                       = time.Hour
 )
 
 func NewApprovalManager(log logrus.FieldLogger, clientset kubernetes.Interface) *ApprovalManager {
@@ -148,8 +151,8 @@ func (m *ApprovalManager) runAutoApproveForCastAINodes(ctx context.Context, c <-
 					"signer": csr.SignerName(),
 					"csr":    csr.Name(),
 				})
-				if shouldSkip(log, csr) {
-					log.Debug("skipping csr")
+				if skip, reason := shouldSkip(csr); skip {
+					log.Infof("skipping csr due to reason: %s", reason)
 					return
 				}
 				log.Info("auto approving csr")
@@ -221,32 +224,26 @@ func (m *ApprovalManager) handle(ctx context.Context, log logrus.FieldLogger, cs
 	return errors.New("certificate signing request was not approved")
 }
 
-func shouldSkip(log logrus.FieldLogger, csr *wrapper.CSR) bool {
+func shouldSkip(csr *wrapper.CSR) (bool, string) {
 	if csr.Approved() {
-		log.Debug("csr already approved")
-		return true
+		return true, "csr already approved"
 	}
 	if time.Since(csr.CreatedAt()) > csrOutdatedAfter {
-		log.Debug("csr is outdated")
-		return true
+		return true, fmt.Sprintf("csr is outdated, %v is larger than %v", time.Since(csr.CreatedAt()), csrOutdatedAfter)
 	}
 	if !managedSigner(csr.SignerName()) {
-		log.Debug("csr unknown signer")
-		return true
+		return true, fmt.Sprintf("csr unknown signer: %s", csr.SignerName())
 	}
 	if !managedCSRNamePrefix(csr.Name()) {
-		log.Debug("csr name not managed by CAST AI: ", csr.Name())
-		return true
+		return true, fmt.Sprintf("csr name not managed by CAST AI: %s", csr.Name())
 	}
 	if !managedCSRRequestingUser(csr.RequestingUser()) {
-		log.Debug("csr requesting user is not managed by CAST AI")
-		return true
+		return true, fmt.Sprintf("csr requesting user is not managed by CAST AI: %s", csr.RequestingUser())
 	}
 	if !managerSubjectCommonName(csr.ParsedCertificateRequest().Subject.CommonName) {
-		log.Debug("csr common name is not managed by CAST AI")
-		return true
+		return true, fmt.Sprintf("csr common name is not managed by CAST AIL %s", csr.ParsedCertificateRequest().Subject.CommonName)
 	}
-	return false
+	return false, ""
 }
 
 func managedSigner(signerName string) bool {
@@ -259,7 +256,10 @@ func managedCSRNamePrefix(n string) bool {
 }
 
 func managedCSRRequestingUser(s string) bool {
-	return s == kubeletBootstrapRequestingUser || s == clusterControllerSAName || strings.HasPrefix(s, "system:node:")
+	return s == kubeletBootstrapRequestingUser || // kubelet bootstrap user variation
+		s == kubeletNodepoolBootstrapRequestingUser || // kubelet bootstrap user variation (observed initially on GKE 1.33+)
+		s == clusterControllerSAName || // if created by CC
+		strings.HasPrefix(s, "system:node:") // Post-bootstrap node user; usually for serving certificate
 }
 
 func managerSubjectCommonName(commonName string) bool {

--- a/internal/actions/csr/svc_test.go
+++ b/internal/actions/csr/svc_test.go
@@ -78,7 +78,7 @@ func TestCSRApprove(t *testing.T) {
 
 		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
 		r.NoError(err)
-		r.Len(csrResult.Status.Conditions, 1)
+		r.GreaterOrEqual(len(csrResult.Status.Conditions), 1)
 
 		r.Equal(csrResult.Status.Conditions[0].Type, certv1.CertificateApproved)
 	})
@@ -148,7 +148,7 @@ func TestCSRApprove(t *testing.T) {
 
 		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
 		r.NoError(err)
-		r.Len(csrResult.Status.Conditions, 1)
+		r.GreaterOrEqual(len(csrResult.Status.Conditions), 1)
 
 		r.Equal(csrResult.Status.Conditions[0].Type, certv1.CertificateApproved)
 	})
@@ -184,7 +184,7 @@ func TestCSRApprove(t *testing.T) {
 
 		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
 		r.NoError(err)
-		r.Len(csrResult.Status.Conditions, 1)
+		r.GreaterOrEqual(len(csrResult.Status.Conditions), 1)
 
 		r.Equal(csrResult.Status.Conditions[0].Type, certv1.CertificateApproved)
 	})

--- a/internal/actions/csr/svc_test.go
+++ b/internal/actions/csr/svc_test.go
@@ -78,6 +78,7 @@ func TestCSRApprove(t *testing.T) {
 
 		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
 		r.NoError(err)
+		r.Len(csrResult.Status.Conditions, 1)
 
 		r.Equal(csrResult.Status.Conditions[0].Type, certv1.CertificateApproved)
 	})
@@ -88,6 +89,112 @@ func TestCSRApprove(t *testing.T) {
 
 		csrName := "123"
 		userName := "kubelet-bootstrap"
+		client := fake.NewClientset(getCSRv1(csrName, userName))
+		s := NewApprovalManager(log, client)
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("certificatesigningrequests", ktest.DefaultWatchReactor(watcher, nil))
+
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := s.Start(ctx); err != nil {
+				t.Logf("failed to start approval manager: %s", err.Error())
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			watcher.Add(getCSRv1(csrName, userName))
+			time.Sleep(100 * time.Millisecond)
+			s.Stop()
+		}()
+
+		wg.Wait()
+
+		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+		r.NoError(err)
+		r.Len(csrResult.Status.Conditions, 0)
+	})
+
+	t.Run("approves for kubelet-bootstrap user", func(t *testing.T) {
+		r := require.New(t)
+		t.Parallel()
+
+		csrName := "node-csr-123"
+		userName := "kubelet-bootstrap"
+		client := fake.NewClientset(getCSRv1(csrName, userName))
+		s := NewApprovalManager(log, client)
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("certificatesigningrequests", ktest.DefaultWatchReactor(watcher, nil))
+
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := s.Start(ctx); err != nil {
+				t.Logf("failed to start approval manager: %s", err.Error())
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			watcher.Add(getCSRv1(csrName, userName))
+			time.Sleep(100 * time.Millisecond)
+			s.Stop()
+		}()
+
+		wg.Wait()
+
+		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+		r.NoError(err)
+		r.Len(csrResult.Status.Conditions, 1)
+
+		r.Equal(csrResult.Status.Conditions[0].Type, certv1.CertificateApproved)
+	})
+
+	t.Run("approves for kubelet-nodepool-bootstrap user", func(t *testing.T) {
+		r := require.New(t)
+		t.Parallel()
+
+		csrName := "node-csr-123"
+		userName := "kubelet-nodepool-bootstrap"
+		client := fake.NewClientset(getCSRv1(csrName, userName))
+		s := NewApprovalManager(log, client)
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("certificatesigningrequests", ktest.DefaultWatchReactor(watcher, nil))
+
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := s.Start(ctx); err != nil {
+				t.Logf("failed to start approval manager: %s", err.Error())
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			watcher.Add(getCSRv1(csrName, userName))
+			time.Sleep(100 * time.Millisecond)
+			s.Stop()
+		}()
+
+		wg.Wait()
+
+		csrResult, err := client.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+		r.NoError(err)
+		r.Len(csrResult.Status.Conditions, 1)
+
+		r.Equal(csrResult.Status.Conditions[0].Type, certv1.CertificateApproved)
+	})
+
+	t.Run("skips for unknown user", func(t *testing.T) {
+		r := require.New(t)
+		t.Parallel()
+
+		csrName := "node-csr-123"
+		userName := "some-unknown-user"
 		client := fake.NewClientset(getCSRv1(csrName, userName))
 		s := NewApprovalManager(log, client)
 		watcher := watch.NewFake()


### PR DESCRIPTION
On GKE 1.33 it was observed that the user has changed, causing CSR to not be recognized and ignored. Node was stuck unable to reach apiserver due to this. 

Also made the "skip" log info level as most customers deploy at info and it was impossible to see this was happening live. 